### PR TITLE
Performing connected components is now fast because it returns a gene…

### DIFF
--- a/STRUCTURE_DISCOVERY_PY/profiling.py
+++ b/STRUCTURE_DISCOVERY_PY/profiling.py
@@ -1,0 +1,15 @@
+import cProfile
+
+
+def profiler(func):
+    def profiled_func(*args, **kwargs):
+        profile = cProfile.Profile()
+        try:
+            profile.enable()
+            result = func(*args, **kwargs)
+            profile.disable()
+            return result
+        finally:
+            profile.print_stats()
+    return profiled_func
+

--- a/STRUCTURE_DISCOVERY_PY/structures.py
+++ b/STRUCTURE_DISCOVERY_PY/structures.py
@@ -1,7 +1,7 @@
-from operator import itemgetter
 from math import log
 import numpy as np
 import networkx as nx
+from operator import itemgetter
 
 
 def ln(n):


### PR DESCRIPTION
…rator and we used to sort it, but because of our upper bound for GCC size, we don't need to sort it so the performance hit shows up in the next step of slash burn
